### PR TITLE
feat(export): Allow Exporting Complete Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/lang-sql",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "SQL language support for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -4,18 +4,18 @@ import {syntaxTree} from "@codemirror/language"
 import {SyntaxNode} from "@lezer/common"
 import {Type, Keyword} from "./sql.grammar.terms"
 
-function tokenBefore(tree: SyntaxNode) {
+export function tokenBefore(tree: SyntaxNode) {
   let cursor = tree.cursor.moveTo(tree.from, -1)
   while (/Comment/.test(cursor.name)) cursor.moveTo(cursor.from, -1)
   return cursor.node
 }
 
-function stripQuotes(name: string) {
+export function stripQuotes(name: string) {
   let quoted = /^[`'"](.*)[`'"]$/.exec(name)
   return quoted ? quoted[1] : name
 }
 
-function sourceContext(state: EditorState, startPos: number) {
+export function sourceContext(state: EditorState, startPos: number) {
   let pos = syntaxTree(state).resolveInner(startPos, -1)
   let empty = false
   if (pos.name == "Identifier" || pos.name == "QuotedIdentifier") {

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -5,6 +5,7 @@ import {styleTags, tags as t} from "@codemirror/highlight"
 import {parser as baseParser} from "./sql.grammar"
 import {tokens, Dialect, tokensFor, SQLKeywords, SQLTypes, dialect} from "./tokens"
 import {completeFromSchema, completeKeywords} from "./complete"
+export * from './complete'
 
 let parser = baseParser.configure({
   props: [


### PR DESCRIPTION
I'm looking to dynamically add config schema to the autocomplete.

I want to be able to know when a user has typed a "parent" as defined by the `sourceContext` method so that I can then make an api call before populating the schema table with the columns returned from the api.

I should be able to do that with easy access to the methods that are written in complete.ts