### PR TITLE
Support autocomplete for tables in a specific schema

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -24,18 +24,49 @@ function sourceContext(state: EditorState, startPos: number) {
     let dot = tokenBefore(pos)
     if (dot && dot.name == ".") {
       let before = tokenBefore(dot)
-      if (before && before.name == "Identifier" || before.name == "QuotedIdentifier")
-        parent = stripQuotes(state.sliceDoc(before.from, before.to))
+      if (before && before.name == "Identifier" || before.name == "QuotedIdentifier") {
+        let table = stripQuotes(state.sliceDoc(before.from, before.to))
+        let schema = null
+        let dot = tokenBefore(before)
+        if (dot && dot.name == ".") {
+          let before = tokenBefore(dot)
+
+          if (before) {
+            let value = stripQuotes(state.sliceDoc(before.from, before.to))
+
+            if (before.name == "Identifier" || before.name == "QuotedIdentifier" || (before.name == "Keyword" && value.toLowerCase() == "public"))
+              schema = value
+          }
+        }
+
+        parent = schema ? `${schema}.${table}` : table
+      }
     }
     return {parent,
             from: pos.from,
             quoted: pos.name == "QuotedIdentifier" ? state.sliceDoc(pos.from, pos.from + 1) : null}
   } else if (pos.name == ".") {
     let before = tokenBefore(pos)
-    if (before && before.name == "Identifier" || before.name == "QuotedIdentifier")
-      return {parent: stripQuotes(state.sliceDoc(before.from, before.to)),
+    if (before && before.name == "Identifier" || before.name == "QuotedIdentifier") {
+      let table = stripQuotes(state.sliceDoc(before.from, before.to))
+      let schema = null
+      let dot = tokenBefore(before)
+
+      if (dot && dot.name == ".") {
+        let before = tokenBefore(dot)
+
+        if (before) {
+          let value = stripQuotes(state.sliceDoc(before.from, before.to))
+
+          if (before.name == "Identifier" || before.name == "QuotedIdentifier" || (before.name == "Keyword" && value.toLowerCase() == "public"))
+            schema = value
+        }
+      }
+
+      return {parent: schema ? `${schema}.${table}` : table,
               from: startPos,
               quoted: null}
+    }
   } else {
     empty = true
   }

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -15,19 +15,21 @@ function stripQuotes(name: string) {
   return quoted ? quoted[1] : name
 }
 
+function isIdentifier(state: EditorState, node: SyntaxNode) {
+  let value = stripQuotes(state.sliceDoc(node.from, node.to)).toLowerCase()
+
+  // Handle a case when a "public" schema is specified, which also counts as a SQL keyword
+  return node.name == "Identifier" || node.name == "QuotedIdentifier" || (node.name == "Keyword" && value == "public")  
+}
+
 function schemaBefore(state: EditorState, tree: SyntaxNode) {
   let dot = tokenBefore(tree)
 
   if (dot && dot.name == ".") {
     let schema = tokenBefore(dot)
 
-    if (schema) {
-      let value = stripQuotes(state.sliceDoc(schema.from, schema.to)).toLowerCase()
-
-      // Handle a case when a "public" schema is specified, which also counts as a SQL keyword
-      if (schema.name == "Identifier" || schema.name == "QuotedIdentifier" || (schema.name == "Keyword" && value == "public")) {
-        return schema
-      }
+    if (schema && isIdentifier(state, schema)) {
+      return schema
     }
   }
 
@@ -37,13 +39,13 @@ function schemaBefore(state: EditorState, tree: SyntaxNode) {
 function sourceContext(state: EditorState, startPos: number) {
   let pos = syntaxTree(state).resolveInner(startPos, -1)
   let empty = false
-  if (pos.name == "Identifier" || pos.name == "QuotedIdentifier") {
+  if (isIdentifier(state, pos)) {
     empty = false
     let parent = null
     let dot = tokenBefore(pos)
     if (dot && dot.name == ".") {
       let before = tokenBefore(dot)
-      if (before && before.name == "Identifier" || before.name == "QuotedIdentifier") {
+      if (before && isIdentifier(state, before)) {
         let table = stripQuotes(state.sliceDoc(before.from, before.to))
         let schema = schemaBefore(state, before)
         let schemaName = schema ? stripQuotes(state.sliceDoc(schema.from, schema.to)) : null
@@ -55,7 +57,7 @@ function sourceContext(state: EditorState, startPos: number) {
             quoted: pos.name == "QuotedIdentifier" ? state.sliceDoc(pos.from, pos.from + 1) : null}
   } else if (pos.name == ".") {
     let before = tokenBefore(pos)
-    if (before && before.name == "Identifier" || before.name == "QuotedIdentifier") {
+    if (before && isIdentifier(state, before)) {
       let table = stripQuotes(state.sliceDoc(before.from, before.to))
       let schema = schemaBefore(state, before)
       let schemaName = schema ? stripQuotes(state.sliceDoc(schema.from, schema.to)) : null
@@ -80,10 +82,25 @@ const Span = /^\w*$/, QuotedSpan = /^[`'"]?\w*[`'"]?$/
 export function completeFromSchema(schema: {[table: string]: readonly (string | Completion)[]},
                                    tables?: readonly Completion[],
                                    defaultTable?: string): CompletionSource {
+  let bySchema: {[schema: string]: readonly Completion[]} = Object.create(null)
   let byTable: {[table: string]: readonly Completion[]} = Object.create(null)
-  for (let table in schema) byTable[table] = schema[table].map(val => {
-    return typeof val == "string" ? {label: val, type: "property"} : val
-  })
+
+  for (let table in schema) {
+    if (table.includes(".")) {
+      let [schemaName, tableName] = table.split(".")
+
+      if (!Array.isArray(bySchema[schemaName])) {
+        bySchema[schemaName] = []
+      }
+
+      bySchema[schemaName].push({label: tableName, type: "type"})
+    }
+
+    byTable[table] = schema[table].map(val => {
+      return typeof val == "string" ? {label: val, type: "property"} : val    
+    })
+  }
+
   let topOptions: readonly Completion[] =
     (tables || Object.keys(byTable).map(name => ({label: name, type: "type"} as Completion)))
     .concat(defaultTable && byTable[defaultTable] || [])
@@ -93,9 +110,9 @@ export function completeFromSchema(schema: {[table: string]: readonly (string | 
     if (empty && !context.explicit) return null
     let options = topOptions
     if (parent) {
-      let columns = byTable[parent]
-      if (!columns) return null
-      options = columns
+      let completions = bySchema[parent] || byTable[parent]
+      if (!completions) return null
+      options = completions
     }
     let quoteAfter = quoted && context.state.sliceDoc(context.pos, context.pos + 1) == quoted
     return {

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -43,6 +43,18 @@ describe("SQL completion", () => {
     ist(str(get('select "u|', {schema: schema1})), '"products", "users"')
   })
 
+  it("completes table names under schema", () => {
+    ist(str(get("select public.u|", {schema: schema2})), "users")
+  })
+
+  it("completes quoted table names under schema", () => {
+    ist(str(get('select public."u|', {schema: schema2})), '"users"')
+  })
+
+  it("completes quoted table names under quoted schema", () => {
+    ist(str(get('select "public"."u|', {schema: schema2})), '"users"')
+  })
+
   it("completes column names", () => {
     ist(str(get("select users.|", {schema: schema1})), "address, id, name")
   })

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -55,7 +55,7 @@ describe("SQL completion", () => {
     ist(str(get('select "users".|', {schema: schema1})), "address, id, name")
   })
 
-  it("complets column names in tables for a specific schema", () => {
+  it("completes column names in tables for a specific schema", () => {
     ist(str(get("select public.users.|", {schema: schema2})), "email, id")
     ist(str(get("select other.users.|", {schema: schema2})), "id, name")
   })

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -29,6 +29,11 @@ let schema1 = {
   products: ["name", "cost", "description"]
 }
 
+let schema2 = {
+  "public.users": ["email", "id"],
+  "other.users": ["name", "id"]
+}
+
 describe("SQL completion", () => {
   it("completes table names", () => {
     ist(str(get("select u|", {schema: schema1})), "products, users")
@@ -48,6 +53,31 @@ describe("SQL completion", () => {
 
   it("completes column names in quoted tables", () => {
     ist(str(get('select "users".|', {schema: schema1})), "address, id, name")
+  })
+
+  it("complets column names in tables for a specific schema", () => {
+    ist(str(get("select public.users.|", {schema: schema2})), "email, id")
+    ist(str(get("select other.users.|", {schema: schema2})), "id, name")
+  })
+
+  it("completes quoted column names in tables for a specific schema", () => {
+    ist(str(get('select public.users."|', {schema: schema2})), '"email", "id"')
+    ist(str(get('select other.users."|', {schema: schema2})), '"id", "name"')
+  })
+
+  it("completes column names in quoted tables for a specific schema", () => {
+    ist(str(get('select public."users".|', {schema: schema2})), "email, id")
+    ist(str(get('select other."users".|', {schema: schema2})), "id, name")
+  })
+
+  it("completes column names in quoted tables for a specific quoted schema", () => {
+    ist(str(get('select "public"."users".|', {schema: schema2})), "email, id")
+    ist(str(get('select "other"."users".|', {schema: schema2})), "id, name")
+  })
+
+  it("completes quoted column names in quoted tables for a specific quoted schema", () => {
+    ist(str(get('select "public"."users"."|', {schema: schema2})), '"email", "id"')
+    ist(str(get('select "other"."users"."|', {schema: schema2})), '"id", "name"')
   })
 
   it("includes closing quote in completion", () => {


### PR DESCRIPTION
This PR adds support for specifying schema alongside a table, like so:

```sql
select * from my_schema.users where my_schema.users.id = 1
```

Currently, this package doesn't show any autocomplete suggestions when you specify a schema, even if you pass a config like this:

```js
const config = {
  schema: {
    "my_schema.users": ["id", "email"]
  }
}
```

It also supports a default `public` schema. However, it's specified as a SQL keyword in this package, so this PR needs to specifically handle this case as an exception from other schema names. See `schemaBefore` function for details. I extracted the code to parse a schema into a function to avoid code duplication and to make it cleaner.

I also added the tests for various combinations for queries with and without quotes.