### PR TITLE
Parse more variations of bits and bytes

### DIFF
--- a/src/sql.grammar
+++ b/src/sql.grammar
@@ -14,6 +14,8 @@ element {
   Null |
   Identifier |
   QuotedIdentifier |
+  Bits |
+  Bytes |
   Builtin |
   SpecialVar |
   CompositeIdentifier {
@@ -51,6 +53,8 @@ element {
   QuotedIdentifier
   Keyword
   Type
+  Bits
+  Bytes
   Builtin
 }
 

--- a/src/sql.grammar.terms.d.ts
+++ b/src/sql.grammar.terms.d.ts
@@ -2,4 +2,4 @@ export const whitespace: number, LineComment: number, BlockComment: number,
   String: number, Number: number, Bool: number, Null: number,
   ParenL: number, ParenR: number, BraceL: number, BraceR: number, BracketL: number, BracketR: number, Semi: number, Dot: number,
   Operator: number, Punctuation: number, SpecialVar: number, Identifier: number, QuotedIdentifier: number,
-  Keyword: number, Type: number, Builtin: number
+  Keyword: number, Type: number, Builtin: number, Bits: number, Bytes: number

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -19,6 +19,8 @@ let parser = baseParser.configure({
       Keyword: t.keyword,
       Type: t.typeName,
       Builtin: t.standard(t.name),
+      Bits: t.number,
+      Bytes: t.string,
       Bool: t.bool,
       Null: t.null,
       Number: t.number,
@@ -70,6 +72,12 @@ type SQLDialectSpec = {
   /// The characters that can be used to quote identifiers. Defaults
   /// to `"\""`.
   identifierQuotes?: string
+  /// Controls whether bit values can be defined as 0b1010. Defaults
+  /// to false.
+  unquotedBitLiterals?: boolean,
+  // Controls whether bit values can contain other characters than 0 and 1.
+  // Defaults to false.
+  treatBitsAsBytes?: boolean,
 }
 
 /// Represents an SQL dialect.
@@ -183,6 +191,7 @@ export const MySQL = SQLDialect.define({
   operatorChars: "*+-%<>!=&|^",
   charSetCasts: true,
   doubleQuotedStrings: true,
+  unquotedBitLiterals: true,
   hashComments: true,
   spaceAfterDashes: true,
   specialVar: "@?",
@@ -198,6 +207,7 @@ export const MariaSQL = SQLDialect.define({
   operatorChars: "*+-%<>!=&|^",
   charSetCasts: true,
   doubleQuotedStrings: true,
+  unquotedBitLiterals: true,
   hashComments: true,
   spaceAfterDashes: true,
   specialVar: "@?",

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -1,0 +1,48 @@
+import ist from "ist"
+import {PostgreSQL, MySQL, SQLDialect} from "@codemirror/lang-sql"
+
+const mysqlTokens = MySQL.language
+const postgresqlTokens = PostgreSQL.language
+const bigQueryTokens = SQLDialect.define({
+    treatBitsAsBytes: true
+}).language
+
+describe("Parse MySQL tokens", () => {
+    const parser = mysqlTokens.parser
+
+    it("parses quoted bit-value literals", () => {
+        ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bits))')
+    })
+
+    it("parses unquoted bit-value literals", () => {
+        ist(parser.parse("SELECT 0b01"), 'Script(Statement(Keyword,Bits))')
+    })
+})
+
+describe("Parse PostgreSQL tokens", () => {
+    const parser = postgresqlTokens.parser
+
+    it("parses quoted bit-value literals", () => {
+        ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bits))')
+    })
+})
+
+describe("Parse BigQuery tokens", () => {
+    const parser = bigQueryTokens.parser
+
+    it("parses quoted bytes literals in single quotes", () => {
+        ist(parser.parse("SELECT b'abcd'"), 'Script(Statement(Keyword,Bytes))')
+    })
+
+    it("parses quoted bytes literals in double quotes", () => {
+        ist(parser.parse('SELECT b"abcd"'), 'Script(Statement(Keyword,Bytes))')
+    })
+
+    it("parses bytes literals in single quotes", () => {
+        ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bytes))')
+    })
+
+    it("parses bytes literals in double quotes", () => {
+        ist(parser.parse('SELECT b"0101"'), 'Script(Statement(Keyword,Bytes))')
+    })
+})

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -25,6 +25,10 @@ describe("Parse PostgreSQL tokens", () => {
     it("parses quoted bit-value literals", () => {
         ist(parser.parse("SELECT b'0101'"), 'Script(Statement(Keyword,Bits))')
     })
+
+    it("parses quoted bit-value literals", () => {
+        ist(parser.parse("SELECT B'0101'"), 'Script(Statement(Keyword,Bits))')
+    })
 })
 
 describe("Parse BigQuery tokens", () => {


### PR DESCRIPTION
This adds new tokens for bits and bytes. We now support these three variations of bits and bytes syntax:
* Regular bit style: b'0101'
* Unquoted bit style (MySQL): 0b0101
* Byte style (BigQuery): b'abcd'

I've also added a few tests for these new parsers.

This work was triggered to resolve this syntax parsing issue for BigQuery byte strings:
<img width="335" alt="Screenshot 2022-08-13 at 23 46 18" src="https://user-images.githubusercontent.com/190349/184511762-f2eb8fcd-2183-440e-8dd2-1c5f88a2e8dc.png">

PostgreSQL 14 Reference: https://www.postgresql.org/docs/14/functions-bitstring.html
MySQL 8.0 Reference: https://dev.mysql.com/doc/refman/8.0/en/bit-value-literals.html
BigQuery Example: https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#byte_length