### PR TITLE
Support autocompletion with table aliases

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -53,7 +53,7 @@ function resolveAlias(state: EditorState, node: SyntaxNode, parents: string[]): 
     for (let searchNode = findFromClause(state, node.parent)?.nextSibling; searchNode != null && !isKeyword(state, searchNode, "WHERE"); searchNode = searchNode.nextSibling) {
       if ((searchNode.name == "Identifier" || searchNode.name == "QuotedIdentifier") && stripQuotes(state.sliceDoc(searchNode.from, searchNode.to)) === aliasName) {
         let sourceNode = isKeyword(state, searchNode.prevSibling, "AS") ? searchNode.prevSibling.prevSibling : searchNode.prevSibling;
-        if (sourceNode?.name.endsWith("Identifier")) { // can be Identifier, QuotedIdentifier or CompositeIdentifier
+        if (sourceNode && /Identifier$/.test(sourceNode.name)) { // can be Identifier, QuotedIdentifier or CompositeIdentifier
           return state.sliceDoc(sourceNode.from, sourceNode.to).split(".").map(stripQuotes);
         }
       }

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -36,7 +36,7 @@ function sourceContext(state: EditorState, startPos: number) {
   if (pos.name == "Identifier" || pos.name == "QuotedIdentifier") {
     return {from: pos.from,
             quoted: pos.name == "QuotedIdentifier" ? state.sliceDoc(pos.from, pos.from + 1) : null,
-            parents: parentsFor(state, tokenBefore(pos))}
+            parents: resolveAlias(state, pos, parentsFor(state, tokenBefore(pos)))}
   } if (pos.name == ".") {
     return {from: startPos,
             quoted: null,

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -93,29 +93,31 @@ describe("SQL completion", () => {
   })
 
   it("completes column names of aliased tables", () => {
-    ist(str(get("select u.| FROM users u", {schema: schema1})), "address, id, name")
-    ist(str(get("select u.| FROM users as u", {schema: schema1})), "address, id, name")
-    ist(str(get("select * FROM users u WHERE u.|", {schema: schema1})), "address, id, name")
-    ist(str(get("select * FROM users as u WHERE u.|", {schema: schema1})), "address, id, name")
+    ist(str(get("select u.| from users u", {schema: schema1})), "address, id, name")
+    ist(str(get("select u.| from users as u", {schema: schema1})), "address, id, name")
+    ist(str(get("select u.| from (SELECT * FROM something u) join users u", {schema: schema1})), "address, id, name")
+    ist(str(get("select * from users u where u.|", {schema: schema1})), "address, id, name")
+    ist(str(get("select * from users as u where u.|", {schema: schema1})), "address, id, name")
+    ist(str(get("select * from (SELECT * FROM something u) join users u where u.|", {schema: schema1})), "address, id, name")
   })
 
   it("completes column names of aliased quoted tables", () => {
-    ist(str(get('select u.| FROM "users" u', {schema: schema1})), "address, id, name")
-    ist(str(get('select u.| FROM "users" as u', {schema: schema1})), "address, id, name")
-    ist(str(get('select * FROM "users" u WHERE u.|', {schema: schema1})), "address, id, name")
-    ist(str(get('select * FROM "users" as u WHERE u.|', {schema: schema1})), "address, id, name")
+    ist(str(get('select u.| from "users" u', {schema: schema1})), "address, id, name")
+    ist(str(get('select u.| from "users" as u', {schema: schema1})), "address, id, name")
+    ist(str(get('select * from "users" u where u.|', {schema: schema1})), "address, id, name")
+    ist(str(get('select * from "users" as u where u.|', {schema: schema1})), "address, id, name")
   })
 
   it("completes column names of aliased tables for a specific schema", () => {
-    ist(str(get("select u.| FROM public.users u", {schema: schema2})), "email, id")
+    ist(str(get("select u.| from public.users u", {schema: schema2})), "email, id")
   })
 
   it("completes column names in aliased quoted tables for a specific schema", () => {
-    ist(str(get('select u.| FROM public."users" u', {schema: schema2})), "email, id")
+    ist(str(get('select u.| from public."users" u', {schema: schema2})), "email, id")
   })
 
   it("completes column names in aliased quoted tables for a specific quoted schema", () => {
-    ist(str(get('select u.| FROM "public"."users" u', {schema: schema2})), "email, id")
+    ist(str(get('select u.| from "public"."users" u', {schema: schema2})), "email, id")
   })
 
   it("includes closing quote in completion", () => {

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -92,6 +92,32 @@ describe("SQL completion", () => {
     ist(str(get('select "other"."users"."|', {schema: schema2})), '"id", "name"')
   })
 
+  it("completes column names of aliased tables", () => {
+    ist(str(get("select u.| FROM users u", {schema: schema1})), "address, id, name")
+    ist(str(get("select u.| FROM users as u", {schema: schema1})), "address, id, name")
+    ist(str(get("select * FROM users u WHERE u.|", {schema: schema1})), "address, id, name")
+    ist(str(get("select * FROM users as u WHERE u.|", {schema: schema1})), "address, id, name")
+  })
+
+  it("completes column names of aliased quoted tables", () => {
+    ist(str(get('select u.| FROM "users" u', {schema: schema1})), "address, id, name")
+    ist(str(get('select u.| FROM "users" as u', {schema: schema1})), "address, id, name")
+    ist(str(get('select * FROM "users" u WHERE u.|', {schema: schema1})), "address, id, name")
+    ist(str(get('select * FROM "users" as u WHERE u.|', {schema: schema1})), "address, id, name")
+  })
+
+  it("completes column names of aliased tables for a specific schema", () => {
+    ist(str(get("select u.| FROM public.users u", {schema: schema2})), "email, id")
+  })
+
+  it("completes column names in aliased quoted tables for a specific schema", () => {
+    ist(str(get('select u.| FROM public."users" u', {schema: schema2})), "email, id")
+  })
+
+  it("completes column names in aliased quoted tables for a specific quoted schema", () => {
+    ist(str(get('select u.| FROM "public"."users" u', {schema: schema2})), "email, id")
+  })
+
   it("includes closing quote in completion", () => {
     let r = get('select "u|"', {schema: schema1})
     ist(r!.to, 10)


### PR DESCRIPTION
Table names are only searched for between FROM and WHERE (if present) and only on the same level as the alias usage, so false positives should not appear.
It might not be implemented in the most performant way since I'm not familiar with token traversal in CM 6, but I hope it's not too bad. I only tested small queries, which are fine.