### PR TITLE
Fix -- line comments for MariaSQL / MySQL

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -189,7 +189,7 @@ export function tokensFor(d: Dialect) {
       eol(input)
       input.acceptToken(LineComment)
     } else if (next == Ch.Dash && input.next == Ch.Dash &&
-               (!d.spaceAfterDashes || input.peek(2) == Ch.Space)) {
+               (!d.spaceAfterDashes || input.peek(1) == Ch.Space)) {
       eol(input)
       input.acceptToken(LineComment)
     } else if (next == Ch.Slash && input.next == Ch.Star) {


### PR DESCRIPTION
The required space after two dashes was checked at the wrong index.