### PR TITLE
Add support for async table schemas

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -93,7 +93,7 @@ function maybeQuoteCompletions(quote: string | null, completions: readonly Compl
 const Span = /^\w*$/, QuotedSpan = /^[`'"]?\w*[`'"]?$/
 
 class CompletionLevel {
-  list: readonly (string | Completion)[] | Promise<(string | Completion)[]> = []
+  list: readonly (string | Completion)[] | (() => Promise<(string | Completion)[]>) = []
   children: {[name: string]: CompletionLevel} | undefined = undefined
 
   child(name: string) {
@@ -106,7 +106,7 @@ class CompletionLevel {
   }
 }
 
-export function completeFromSchema(schema: {[table: string]: readonly (string | Completion)[] | Promise<(string | Completion)[]>},
+export function completeFromSchema(schema: {[table: string]: readonly (string | Completion)[] | (() => Promise<(string | Completion)[]>)},
                                    tables?: readonly Completion[],
                                    defaultTableName?: string, defaultSchemaName?: string): CompletionSource {
   let top = new CompletionLevel
@@ -139,7 +139,8 @@ export function completeFromSchema(schema: {[table: string]: readonly (string | 
       level = level.child(name)
     }
     let quoteAfter = quoted && context.state.sliceDoc(context.pos, context.pos + 1) == quoted
-    let options = (await level.list).map(val => typeof val == "string" ? {label: val, type: "property"} : val)
+    let list = typeof level.list === 'function' ? await level.list() : level.list;
+    let options = list.map(val => typeof val == "string" ? {label: val, type: "property"} : val)
     if (level == top && aliases)
       options = options.concat(Object.keys(aliases).map(name => ({label: name, type: "constant"})))
     return {

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -116,7 +116,7 @@ export interface SQLConfig {
   /// An object that maps table names, optionally prefixed with a
   /// schema name (`"schema.table"`) to options (columns) that can be
   /// completed for that table. Use lower-case names here.
-  schema?: {[table: string]: readonly (string | Completion)[]},
+  schema?: {[table: string]: readonly (string | Completion)[] | Promise<(string | Completion)[]>},
   /// By default, the completions for the table names will be
   /// generated from the `schema` object. But if you want to
   /// customize them, you can pass an array of completions through

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -116,7 +116,7 @@ export interface SQLConfig {
   /// An object that maps table names, optionally prefixed with a
   /// schema name (`"schema.table"`) to options (columns) that can be
   /// completed for that table. Use lower-case names here.
-  schema?: {[table: string]: readonly (string | Completion)[] | Promise<(string | Completion)[]>},
+  schema?: {[table: string]: readonly (string | Completion)[] | (() => Promise<(string | Completion)[]>)},
   /// By default, the completions for the table names will be
   /// generated from the `schema` object. But if you want to
   /// customize them, you can pass an array of completions through


### PR DESCRIPTION
This PR aims to add support for providing table schemas with promises. The motivation is similar with https://github.com/codemirror/lang-sql/pull/2: I'm also looking to fetch table schema on demand. I can do that by playing around with the returned completions from `schemaCompletionSource` but CodeMirror already supports promises for completions - so I thought why not support it internally in the extension itself?

Now we return an async completion source that awaits the level list - so this means a small type change to the `CompletionLevel` type:
```tsx
list: readonly (string | Completion)[] | Promise<(string | Completion)[]> = []
```

And, we also need to do the mapping of strings to completions in the completion source:
```tsx
(await level.list).map(val => typeof val == "string" ? {label: val, type: "property"} : val)
```