### PR TITLE
Parse semicolons inside BEGIN/END block without ending statement

### DIFF
--- a/src/sql.grammar
+++ b/src/sql.grammar
@@ -27,7 +27,8 @@ element {
   Punctuation |
   Parens { ParenL element* ParenR } |
   Braces { BraceL element* BraceR } |
-  Brackets { BracketL element* BracketR }
+  Brackets { BracketL element* BracketR } |
+  BeginEnd { Begin (element | Semi)+ End }
 }
 
 @external tokens tokens from "./tokens" {
@@ -56,6 +57,8 @@ element {
   Bits
   Bytes
   Builtin
+  Begin[@name="begin"]
+  End[@name="end"]
 }
 
 @detectDelim

--- a/src/sql.grammar.terms.d.ts
+++ b/src/sql.grammar.terms.d.ts
@@ -2,4 +2,4 @@ export const whitespace: number, LineComment: number, BlockComment: number,
   String: number, Number: number, Bool: number, Null: number,
   ParenL: number, ParenR: number, BraceL: number, BraceR: number, BracketL: number, BracketR: number, Semi: number, Dot: number,
   Operator: number, Punctuation: number, SpecialVar: number, Identifier: number, QuotedIdentifier: number,
-  Keyword: number, Type: number, Builtin: number, Bits: number, Bytes: number
+  Keyword: number, Type: number, Builtin: number, Bits: number, Bytes: number, Begin: number, End: number

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,7 +2,7 @@ import {ExternalTokenizer, InputStream} from "@lezer/lr"
 import {whitespace, LineComment, BlockComment, String as StringToken, Number, Bits, Bytes, Bool, Null,
         ParenL, ParenR, BraceL, BraceR, BracketL, BracketR, Semi, Dot,
         Operator, Punctuation, SpecialVar, Identifier, QuotedIdentifier,
-        Keyword, Type, Builtin} from "./sql.grammar.terms"
+        Keyword, Type, Builtin, Begin, End} from "./sql.grammar.terms"
 
 const enum Ch {
   Newline = 10,
@@ -27,6 +27,7 @@ const enum Ch {
   Underscore = 95,
   Backtick = 96,
   BraceL = 123, BraceR = 125,
+  Begin = 150, End = 151,
 
   A = 65, a = 97,
   B = 66, b = 98,
@@ -285,7 +286,13 @@ export function tokensFor(d: Dialect) {
       input.acceptToken(Punctuation)
     } else if (isAlpha(next)) {
       let word = readWord(input, String.fromCharCode(next))
-      input.acceptToken(input.next == Ch.Dot ? Identifier : d.words[word.toLowerCase()] ?? Identifier)
+      if (word.toLowerCase() === "begin") {
+        input.acceptToken(Begin)
+      } else if (word.toLowerCase() === "end") {
+        input.acceptToken(End)
+      } else {
+        input.acceptToken(input.next == Ch.Dot ? Identifier : d.words[word.toLowerCase()] ?? Identifier)
+      }
     }
   })
 }


### PR DESCRIPTION
Right now, semicolons indicate the end of statement. If there is a BEGIN/END block with a semicolon, the outer statement is prematurely ended inside of the block.