### PR TITLE
Fix bracket/brace names in sql.grammar

### DIFF
--- a/src/sql.grammar
+++ b/src/sql.grammar
@@ -40,10 +40,10 @@ element {
   Null
   ParenL[@name="("]
   ParenR[@name=")"]
-  BraceL[@name="["]
-  BraceR[@name="]"]
-  BracketL[@name="{"]
-  BracketR[@name="}"]
+  BraceL[@name="{"]
+  BraceR[@name="}"]
+  BracketL[@name="["]
+  BracketR[@name="]"]
   Semi[@name=";"]
   Dot[@name="."]
   Operator


### PR DESCRIPTION
The bracket and brace is switched.

ASCII 91 = "[", which matches "BracketL" at https://github.com/codemirror/lang-sql/blob/main/src/tokens.ts#L25, but was "{" on L45 in sql.grammar