### PR TITLE
Allow adding any types of objects for autcompletion.

### DIFF
--- a/src/sql.ts
+++ b/src/sql.ts
@@ -133,6 +133,7 @@ export interface SQLConfig {
   /// for your schemas rather than using the generated ones, pass them
   /// here.
   schemas?: readonly Completion[],
+  objects?: {[objectType: string]: {[objectName: string]: readonly (string | Completion)[]}},
   /// When given, columns from the named table can be completed
   /// directly at the top level.
   defaultTable?: string,
@@ -159,7 +160,7 @@ export function keywordCompletion(dialect: SQLDialect, upperCase = false): Exten
 /// Returns a completion sources that provides schema-based completion
 /// for the given configuration.
 export function schemaCompletionSource(config: SQLConfig): CompletionSource {
-  return config.schema ? completeFromSchema(config.schema, config.tables, config.schemas,
+  return config.schema ? completeFromSchema(config.schema, config.tables, config.schemas, config.objects,
                                             config.defaultTable, config.defaultSchema,
                                             config.dialect || StandardSQL)
     : () => null

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -39,12 +39,24 @@ describe("SQL completion", () => {
     ist(str(get("select u|", {schema: schema1})), "products, users")
   })
 
+  it("completes table names passed by objects key", () => {
+    ist(str(get("select u|", {schema: {}, objects: {
+      'type1': schema1,
+    }})), "products, users")
+  });
+
   it("completes quoted table names", () => {
     ist(str(get('select "u|', {schema: schema1})), '"products", "users"')
   })
 
   it("completes table names under schema", () => {
     ist(str(get("select public.u|", {schema: schema2})), "users")
+  })
+
+  it("completes table names under schema passed by objects key", () => {
+    ist(str(get("select public.u|", {schema: {}, objects: {
+      'type1': schema2,
+    }})), "users")
   })
 
   it("completes quoted table names under schema", () => {
@@ -59,6 +71,12 @@ describe("SQL completion", () => {
     ist(str(get("select users.|", {schema: schema1})), "address, id, name")
   })
 
+  it("completes column names passed by objects key", () => {
+    ist(str(get("select users.|", {schema: {}, objects: {
+      'type1': schema1,
+    }})), "address, id, name")
+  })
+
   it("completes quoted column names", () => {
     ist(str(get('select users."|', {schema: schema1})), '"address", "id", "name"')
   })
@@ -70,6 +88,15 @@ describe("SQL completion", () => {
   it("completes column names in tables for a specific schema", () => {
     ist(str(get("select public.users.|", {schema: schema2})), "email, id")
     ist(str(get("select other.users.|", {schema: schema2})), "id, name")
+  })
+
+  it("completes column names in tables for a specific schema passed by objects key", () => {
+    ist(str(get("select public.users.|", {schema: {}, objects: {
+      'type1': schema2,
+    }})), "email, id")
+    ist(str(get("select other.users.|", {schema: {}, objects: {
+      'type1': schema2,
+    }})), "id, name")
   })
 
   it("completes quoted column names in tables for a specific schema", () => {
@@ -174,5 +201,5 @@ describe("SQL completion", () => {
     let s = {schema: {"db\\.conf": ["abc"]}}
     ist(str(get("db|", s)), '"db.conf"')
     ist(str(get('"db.conf".|', s)), "abc")
-  })    
+  })
 })


### PR DESCRIPTION
The changes are backward compatible. A new key `objects` is added which would behave just like schemas except with one more level to specify the object type. In schemas, it considers everything as table.