### PR TITLE
SQLDialect identifierCaseInsensitive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ to <code>&quot;\&quot;&quot;</code>.</p>
 </dd><dt id="user-content-sqldialectspec.identifiercaseinsensitive">
   <code><strong><a href="#user-content-sqldialectspec.identifiercaseinsensitive">identifiercaseinsensitive</a></strong>&#8288;?: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code></dt>
 
-<dd><p>Controls whether identifiers are case-insensitive. Identifiers with upper case letters are quoted then set to false. Defaults
+<dd><p>Controls whether identifiers are case-insensitive. Identifiers with upper-case letters are quoted then set to false. Defaults
 to <code>false</code>.</p>
 </dd><dt id="user-content-sqldialectspec.unquotedbitliterals">
   <code><strong><a href="#user-content-sqldialectspec.unquotedbitliterals">unquotedBitLiterals</a></strong>&#8288;?: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code></dt>

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Defaults to <code>&quot;?&quot;</code>.</p>
 
 <dd><p>The characters that can be used to quote identifiers. Defaults
 to <code>&quot;\&quot;&quot;</code>.</p>
+</dd><dt id="user-content-sqldialectspec.identifiercaseinsensitive">
+  <code><strong><a href="#user-content-sqldialectspec.identifiercaseinsensitive">identifiercaseinsensitive</a></strong>&#8288;?: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code></dt>
+
+<dd><p>Controls whether identifiers are case-insensitive. Identifiers with upper case letters are quoted then set to false. Defaults
+to <code>false</code>.</p>
 </dd><dt id="user-content-sqldialectspec.unquotedbitliterals">
   <code><strong><a href="#user-content-sqldialectspec.unquotedbitliterals">unquotedBitLiterals</a></strong>&#8288;?: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code></dt>
 

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -77,7 +77,7 @@ export type SQLDialectSpec = {
   /// to `"\""`.
   identifierQuotes?: string
   /// Controls whether identifiers are case-insensitive. Identifiers
-  /// with upper case letters are quoted then set to false. Defaults to
+  /// with upper-case letters are quoted then set to false. Defaults to
   /// false.
   identifierCaseInsensitive?: boolean,
   /// Controls whether bit values can be defined as 0b1010. Defaults

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -76,6 +76,10 @@ export type SQLDialectSpec = {
   /// The characters that can be used to quote identifiers. Defaults
   /// to `"\""`.
   identifierQuotes?: string
+  /// Controls whether identifiers are case-insensitive. Identifiers
+  /// with upper case letters are quoted then set to false. Defaults to
+  /// false.
+  identifierCaseInsensitive?: boolean,
   /// Controls whether bit values can be defined as 0b1010. Defaults
   /// to false.
   unquotedBitLiterals?: boolean,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -168,6 +168,7 @@ export interface Dialect {
   operatorChars: string,
   specialVar: string,
   identifierQuotes: string,
+  identifierCaseInsensitive: boolean,
   words: {[name: string]: number}
 }
 
@@ -188,6 +189,7 @@ const defaults: Dialect = {
   operatorChars: "*+\-%<>!=&|~^/",
   specialVar: "?",
   identifierQuotes: '"',
+  identifierCaseInsensitive: false,
   words: keywords(SQLKeywords, SQLTypes)
 }
 

--- a/test/test-complete.ts
+++ b/test/test-complete.ts
@@ -1,6 +1,6 @@
 import {EditorState} from "@codemirror/state"
 import {CompletionContext, CompletionResult, CompletionSource} from "@codemirror/autocomplete"
-import {schemaCompletionSource, PostgreSQL, MySQL, SQLConfig} from "@codemirror/lang-sql"
+import {schemaCompletionSource, PostgreSQL, MySQL, SQLConfig, SQLDialect} from "@codemirror/lang-sql"
 import ist from "ist"
 
 function get(doc: string, conf: SQLConfig & {explicit?: boolean} = {}) {
@@ -160,6 +160,15 @@ describe("SQL completion", () => {
         '"b c", "b-c", bup')
     ist(str(get("foo.b|", {schema: {foo: ["b c", "b-c", "bup"]}, dialect: MySQL})),
         '`b c`, `b-c`, bup')
+  })
+
+  it("adds identifiers for upper case completions", () => {
+    ist(str(get("foo.c|", {schema: {foo: ["Column", "cell"]}, dialect: PostgreSQL})),
+        '"Column", cell')
+
+    const customDialect = SQLDialect.define({...PostgreSQL.spec, identifierCaseInsensitive: true})
+    ist(str(get("foo.c|", {schema: {foo: ["Column", "cell"]}, dialect: customDialect})),
+        'Column, cell')
   })
 
   it("supports nesting more than two deep", () => {


### PR DESCRIPTION
I added the identifierCaseInsensitive SQLDialect option to skip quoting upper-case identifiers. By default quotes are added to a table called `MyTable`. The completion won't be quoted with this option set to `true`.