### PR TITLE
allow changing some properties of keyword completions

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -204,12 +204,14 @@ export function completeFromSchema(schema: SQLNamespace,
   }
 }
 
-export function completeKeywords(keywords: {[name: string]: number}, upperCase: boolean) {
-  let completions =  Object.keys(keywords).map(keyword => ({
+export function completeKeywords(keywords: {[name: string]: number}, upperCase: boolean, section?: string | CompletionSection, mapper?: (keywords: Completion[]) => Completion[]) {
+  let completions: Completion[] =  Object.keys(keywords).map(keyword => ({
     label: upperCase ? keyword.toUpperCase() : keyword,
     type: keywords[keyword] == Type ? "type" : keywords[keyword] == Keyword ? "keyword" : "variable",
-    boost: -1
+    boost: -1,
+    ...(section ? {section} : {})
   }))
+  if (mapper) completions = mapper(completions)
   return ifNotIn(["QuotedIdentifier", "SpecialVar", "String", "LineComment", "BlockComment", "."],
                  completeFromList(completions))
 }


### PR DESCRIPTION
right now the keyword completions are impossible to really change in any way, and it's super annoying, because we'd like to have autocomplete sections in our app, but if we put anything in any section, that section will placed below all the hundreds of keywords. we'd love to put the keywords in a section below the other far more important stuff