### PR TITLE
Add support for MSSQL bracket quoted identifiers

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -13,7 +13,7 @@ function tokenBefore(tree: SyntaxNode) {
 
 function idName(doc: Text, node: SyntaxNode): string {
   let text = doc.sliceString(node.from, node.to)
-  let quoted = /^([`'"])(.*)\1$/.exec(text)
+  let quoted = /^([`'"\[])(.*)([`'"\]])$/.exec(text)
   return quoted ? quoted[2] : text
 }
 
@@ -86,12 +86,11 @@ function getAliases(doc: Text, at: SyntaxNode) {
   return aliases
 }
 
-function maybeQuoteCompletions(quote: string | null, completions: readonly Completion[]) {
-  if (!quote) return completions
-  return completions.map(c => ({...c, label: c.label[0] == quote ? c.label : quote + c.label + quote, apply: undefined}))
+function maybeQuoteCompletions(openingQuote: string, closingQuote: string, completions: readonly Completion[]) {
+  return completions.map(c => ({...c, label: c.label[0] == openingQuote ? c.label : openingQuote + c.label + closingQuote, apply: undefined}))
 }
 
-const Span = /^\w*$/, QuotedSpan = /^[`'"]?\w*[`'"]?$/
+const Span = /^\w*$/, QuotedSpan = /^[`'"\[]?\w*[`'"\]]?$/
 
 function isSelfTag(namespace: SQLNamespace): namespace is {self: Completion, children: SQLNamespace} {
   return (namespace as any).self && typeof (namespace as any).self.label == "string"
@@ -156,7 +155,12 @@ class CompletionLevel {
 
 function nameCompletion(label: string, type: string, idQuote: string, idCaseInsensitive: boolean): Completion {
   if ((new RegExp("^[a-z_][a-z_\\d]*$", idCaseInsensitive ? "i" : "")).test(label)) return {label, type}
-  return {label, type, apply: idQuote + label + idQuote}
+
+  return {label, type, apply: idQuote + label + getClosingQuote(idQuote)}
+}
+
+function getClosingQuote(openingQuote: string) {
+  return openingQuote === "[" ? "]" : openingQuote;
 }
 
 // Some of this is more gnarly than it has to be because we're also
@@ -191,15 +195,30 @@ export function completeFromSchema(schema: SQLNamespace,
       if (!next) return null
       level = next
     }
-    let quoteAfter = quoted && context.state.sliceDoc(context.pos, context.pos + 1) == quoted
+
     let options = level.list
     if (level == top && aliases)
       options = options.concat(Object.keys(aliases).map(name => ({label: name, type: "constant"})))
-    return {
-      from,
-      to: quoteAfter ? context.pos + 1 : undefined,
-      options: maybeQuoteCompletions(quoted, options),
-      validFor: quoted ? QuotedSpan : Span
+
+    if (quoted) {
+      let openingQuote = quoted[0]
+      let closingQuote = getClosingQuote(openingQuote);
+
+      let quoteAfter = context.state.sliceDoc(context.pos, context.pos + 1) == closingQuote
+
+      return {
+        from,
+        to: quoteAfter ? context.pos + 1 : undefined,
+        options: maybeQuoteCompletions(openingQuote, closingQuote, options),
+        validFor: QuotedSpan,
+      }
+    }
+    else {
+      return {
+        from,
+        options: options,
+        validFor: Span
+      }
     }
   }
 }

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -212,8 +212,7 @@ export function completeFromSchema(schema: SQLNamespace,
         options: maybeQuoteCompletions(openingQuote, closingQuote, options),
         validFor: QuotedSpan,
       }
-    }
-    else {
+    } else {
       return {
         from,
         options: options,

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -75,7 +75,7 @@ export type SQLDialectSpec = {
   /// Defaults to `"?"`.
   specialVar?: string,
   /// The characters that can be used to quote identifiers. Defaults
-  /// to `"\""`. Set to "[" to quote with brackets (MSSQL)
+  /// to `"\""`. Add `[` for MSSQL-style bracket quoted identifiers.
   identifierQuotes?: string
   /// Controls whether identifiers are case-insensitive. Identifiers
   /// with upper-case letters are quoted when set to false (which is
@@ -87,8 +87,6 @@ export type SQLDialectSpec = {
   /// Controls whether bit values can contain other characters than 0 and 1.
   /// Defaults to false.
   treatBitsAsBytes?: boolean,
-  /// Enables recognition of syntax like `[My Table]` as quoted identifiers
-  mssqlBracketQuotingMechanism?: boolean
 }
 
 /// Represents an SQL dialect.
@@ -321,7 +319,7 @@ export const MSSQL = SQLDialect.define({
   builtin: MSSQLBuiltin,
   operatorChars: "*+-%<>!=^&|/",
   specialVar: "@",
-  mssqlBracketQuotingMechanism: true
+  identifierQuotes: "\"["
 })
 
 /// [SQLite](https://sqlite.org/) dialect.

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -75,7 +75,7 @@ export type SQLDialectSpec = {
   /// Defaults to `"?"`.
   specialVar?: string,
   /// The characters that can be used to quote identifiers. Defaults
-  /// to `"\""`.
+  /// to `"\""`. Set to "[" to quote with brackets (MSSQL)
   identifierQuotes?: string
   /// Controls whether identifiers are case-insensitive. Identifiers
   /// with upper-case letters are quoted when set to false (which is
@@ -87,6 +87,8 @@ export type SQLDialectSpec = {
   /// Controls whether bit values can contain other characters than 0 and 1.
   /// Defaults to false.
   treatBitsAsBytes?: boolean,
+  /// Enables recognition of syntax like `[My Table]` as quoted identifiers
+  mssqlBracketQuotingMechanism?: boolean
 }
 
 /// Represents an SQL dialect.
@@ -318,7 +320,8 @@ export const MSSQL = SQLDialect.define({
   types: SQLTypes + "smalldatetime datetimeoffset datetime2 datetime bigint smallint smallmoney tinyint money real text nvarchar ntext varbinary image hierarchyid uniqueidentifier sql_variant xml",
   builtin: MSSQLBuiltin,
   operatorChars: "*+-%<>!=^&|/",
-  specialVar: "@"
+  specialVar: "@",
+  mssqlBracketQuotingMechanism: true
 })
 
 /// [SQLite](https://sqlite.org/) dialect.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -169,7 +169,8 @@ export interface Dialect {
   specialVar: string,
   identifierQuotes: string,
   caseInsensitiveIdentifiers: boolean,
-  words: {[name: string]: number}
+  words: {[name: string]: number},
+  mssqlBracketQuotingMechanism: boolean,
 }
 
 export const SQLTypes = "array binary bit boolean char character clob date decimal double float int integer interval large national nchar nclob numeric object precision real smallint time timestamp varchar varying "
@@ -190,7 +191,8 @@ const defaults: Dialect = {
   specialVar: "?",
   identifierQuotes: '"',
   caseInsensitiveIdentifiers: false,
-  words: keywords(SQLKeywords, SQLTypes)
+  words: keywords(SQLKeywords, SQLTypes),
+  mssqlBracketQuotingMechanism: false,
 }
 
 export function dialect(spec: Partial<Dialect>, kws?: string, types?: string, builtin?: string): Dialect {
@@ -269,6 +271,9 @@ export function tokensFor(d: Dialect) {
       input.advance(2)
       readPLSQLQuotedLiteral(input, openDelim)
       input.acceptToken(StringToken)
+    } else if (d.mssqlBracketQuotingMechanism && next == Ch.BracketL) {
+      readLiteral(input, Ch.BracketR, false)
+      input.acceptToken(QuotedIdentifier)
     } else if (next == Ch.ParenL) {
       input.acceptToken(ParenL)
     } else if (next == Ch.ParenR) {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -169,7 +169,7 @@ export interface Dialect {
   specialVar: string,
   identifierQuotes: string,
   caseInsensitiveIdentifiers: boolean,
-  words: {[name: string]: number},
+  words: {[name: string]: number}
 }
 
 export const SQLTypes = "array binary bit boolean char character clob date decimal double float int integer interval large national nchar nclob numeric object precision real smallint time timestamp varchar varying "
@@ -190,7 +190,7 @@ const defaults: Dialect = {
   specialVar: "?",
   identifierQuotes: '"',
   caseInsensitiveIdentifiers: false,
-  words: keywords(SQLKeywords, SQLTypes),
+  words: keywords(SQLKeywords, SQLTypes)
 }
 
 export function dialect(spec: Partial<Dialect>, kws?: string, types?: string, builtin?: string): Dialect {

--- a/test/test-tokens.ts
+++ b/test/test-tokens.ts
@@ -1,5 +1,5 @@
 import ist from "ist"
-import {PostgreSQL, MySQL, PLSQL, SQLDialect} from "@codemirror/lang-sql"
+import {PostgreSQL, MySQL, PLSQL, SQLDialect, MSSQL} from "@codemirror/lang-sql"
 
 const mysqlTokens = MySQL.language
 const postgresqlTokens = PostgreSQL.language
@@ -7,6 +7,7 @@ const bigQueryTokens = SQLDialect.define({
   treatBitsAsBytes: true
 }).language
 const plsqlTokens = PLSQL.language
+const mssqlTokens = MSSQL.language
 
 describe("Parse MySQL tokens", () => {
   const parser = mysqlTokens.parser
@@ -89,5 +90,13 @@ describe("Parse PL/SQL tokens", () => {
 
   it("parses alternative quoting mechanism - unclosed", () => {
     ist(parser.parse("SELECT q'~foo'bar' FROM DUAL"), 'Script(Statement(Keyword,String))')
+  })
+})
+
+describe("Parse MSSQL tokens", () => {
+  const parser = mssqlTokens.parser;
+
+  it("parses brackets as QuotedIdentifier", () => {
+    ist(parser.parse("SELECT * FROM [tblTest]"), "Script(Statement(Keyword,Operator,Keyword,QuotedIdentifier))")
   })
 })


### PR DESCRIPTION
This PR adds support for the MSSQL specifc style of quoting identifiers using square brackets.

i.e. in select [u].[Name] from [dbo].[Users] [u] the schema identifiers or aliases in brackets are now correctly recognized as QuotedIdentifiers. This then also makes the schema completion source work as normal with this syntax style.

The unit tests I added should reflect all relevant cases.

To bring the identifierQuotes property in line I decided to simply hard match the bracket pair.
So the identifierQuotes need to be explicitly set to '[' in order to correctly generate the completions wrapped in square brackets.
For me this seemed like the simplest and least intrusive solution, but I'm also open to other suggestions on how this should be implemented.